### PR TITLE
Make label appear properly if set to an initial value

### DIFF
--- a/paper-dropdown-decorator.coffee
+++ b/paper-dropdown-decorator.coffee
@@ -29,4 +29,5 @@ Polymer
     @input.value = value
     @input.selectedItemLabel = @input.value
     @input.$.label?.classList.add 'selectedItem' if @input.value
+    @updateLabelVisibility(value)
     return

--- a/paper-dropdown-decorator.js
+++ b/paper-dropdown-decorator.js
@@ -45,6 +45,7 @@
           _ref.classList.add('selectedItem');
         }
       }
+      this.updateLabelVisibility(value);
     }
   });
 


### PR DESCRIPTION
Call updateLabelVisibility in paper-dropdown-decorator so that the floatingLabel appears properly if set to an initial value, rather than only showing after a click.
